### PR TITLE
Add #to_h and #to_hash methods

### DIFF
--- a/lib/configreader/flat_configreader.rb
+++ b/lib/configreader/flat_configreader.rb
@@ -8,6 +8,11 @@ module ConfigReader
       remove_id_method
     end
 
+    def to_h
+      @data
+    end
+    alias_method :to_hash, :to_h
+
     def method_missing(name)
       @data[name.to_s]
     end

--- a/spec/lib/flat_configreader_spec.rb
+++ b/spec/lib/flat_configreader_spec.rb
@@ -30,5 +30,17 @@ describe ConfigReader::FlatConfigReader do
     }.to raise_error(Errno::ENOENT)
   end
 
+  describe :to_h do
+    let(:expected_hash) { YAML.load_file("spec/config/fake_simple.yml") }
+
+    it "should return a hash" do
+      expect(subject.to_h).to be_a Hash
+    end
+
+    it "should return the correct data" do
+      expect(subject.to_h).to eq expected_hash
+    end
+
+  end
 
 end


### PR DESCRIPTION
I added `to_h` and `to_hash` so I could get all the data at once, to pass as options to an initializer, for example.

BTW, the 2 pull requests to this repo were opened exactly 2 year apart :scream_cat: 